### PR TITLE
Remove forward slash when constructing href for particular path name

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -26,5 +26,8 @@ jQuery(document).ready(function($) {
 
 function set_active_nav() {
     var path = window.location.pathname;
+
+    // Remove the forward slash in front of path name
+    path = path.replace(/^\//, '');
     $('#nav-sidebar a[href="'+ path +'"]').parent().addClass('active');
 }

--- a/js/custom.js
+++ b/js/custom.js
@@ -27,7 +27,7 @@ jQuery(document).ready(function($) {
 function set_active_nav() {
     var path = window.location.pathname;
 
-    // Remove the forward slash in front of path name
-    path = path.replace(/^\//, '');
+    // Remove the forward slash and base url in front of path name
+    path = path.replace(/^\/2016\//, '');
     $('#nav-sidebar a[href="'+ path +'"]').parent().addClass('active');
 }


### PR DESCRIPTION
This is a fix for issue #45 

The bug is due to the code not removing "/" (forward slash) while creating href name. Due to this, the sponsorship, faq and COC links aren't getting the required "active" class
